### PR TITLE
Allow passing in custom styles

### DIFF
--- a/src/ProSidebar/ProSidebar.tsx
+++ b/src/ProSidebar/ProSidebar.tsx
@@ -6,6 +6,7 @@ export interface Props {
   rtl?: boolean;
   toggled?: boolean;
   width?: string | number;
+  customStyles?: any,
   image?: string;
   className?: string;
   children?: React.ReactNode;
@@ -26,7 +27,7 @@ export const SidebarContext = createContext<SidebarContextProps>({
 });
 
 const ProSidebar: React.ForwardRefRenderFunction<unknown, Props> = (
-  { children, className, width, collapsed, rtl, toggled, image, breakPoint, onToggle, ...rest },
+  { children, className, width, customStyles, collapsed, rtl, toggled, image, breakPoint, onToggle, ...rest },
   ref,
 ) => {
   const [sidebarState, setSidebarState] = useState({
@@ -56,7 +57,7 @@ const ProSidebar: React.ForwardRefRenderFunction<unknown, Props> = (
         {...rest}
         ref={sidebarRef}
         className={classNames('pro-sidebar', className, breakPoint, { collapsed, rtl, toggled })}
-        style={{ width }}
+        style={{ width, ...customStyles }}
       >
         <div className="pro-sidebar-inner">
           {image ? <img src={image} alt="sidebar background" className="sidebar-bg" /> : null}


### PR DESCRIPTION
### What?

Allow passing in custom CSS styles to the base container `div`. Currently, only `width` is allowed to be passed.
this change allows us to pass set a prop called `customStyles` with an object containing supported standard CSS styles. 

example: `customStyles={color: white, backgroundColor: red}`

### Why?

In one of our projects, We have a use-case where I am trying to set the sidebar color based on some per user configuration, I think it would be a nice addition to the customization of look and feel of sidebar.
I couldn't find a way to override the `background-color` with what is supported now.

Please feel free to recommend any workaround if what I am proposing is not desired

PS: I have 0 experience with typescript, I took a stab at it, happy to take any feedback and improve it or get your input/contribution on this particular change.

cc: @azouaoui-med 