### PR TITLE
Simplify code contributions + reviews by fully automating the dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+tasks:
+  - init: |
+      yarn install && cd demo && yarn install && cd ../
+    command: yarn start:all
+
+ports:
+  - port: 4747
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Peer][peer]][npm-url]
 [![Download][download]][npm-url]
 [![Stars][stars]][github-url]
+[![Gitpod Ready-to-Code][gitpod-badge]][gitpod-url]
 
 [version]: https://img.shields.io/npm/v/react-pro-sidebar.svg?style=flat-square
 [license]: https://img.shields.io/github/license/azouaoui-med/react-pro-sidebar?style=flat-square
@@ -13,6 +14,8 @@
 [stars]: https://img.shields.io/github/stars/azouaoui-med/react-pro-sidebar?style=social
 [npm-url]: https://www.npmjs.com/package/react-pro-sidebar
 [github-url]: https://github.com/azouaoui-med/react-pro-sidebar
+[gitpod-badge]: https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod
+[gitpod-url]: https://gitpod.io/from-referrer/
 
 Customizable and responsive react sidebar library with dropdown menus and unlimited number of nested submenus
 
@@ -211,77 +214,91 @@ import { Link } from 'react-router-dom';
             <td><code>'square'</code> | <code>'round'</code> | <code>'circle'</code></td>
             <td>Shape of the menu icons </td>
             <td>-</td>
-        </tr>  
-         <tr>          
+        </tr>
+         <tr>
             <td>popperArrow</td>
             <td>boolean</td>
             <td>if <code>true</code>, an arrow will be displayed when sidebar collapsed to point to sub-menu wrapper</td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
             <td rowspan=4>MenuItem</td>
             <td>icon</td>
             <td>ReactNode</td>
             <td>Icon for the menu item </td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>active</td>
             <td>boolean</td>
             <td>Set active menu items </td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
             <td>prefix</td>
             <td>ReactNode</td>
             <td>Add a prefix to the menuItem </td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>suffix</td>
             <td>ReactNode</td>
             <td>Add a suffix to the menuItem </td>
             <td>-</td>
-        </tr>          
+        </tr>
         <tr>
             <td rowspan=6>SubMenu</td>
             <td>title</td>
             <td>string | ReactNode</td>
             <td>Title for the submenu </td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>icon</td>
             <td>ReactNode</td>
             <td>Icon for submenu</td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>defaultOpen</td>
             <td>boolean</td>
             <td>Set if the submenu is open by default</td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
             <td>open</td>
             <td>boolean</td>
             <td>Set open value if you want to control the state</td>
             <td>-</td>
-        </tr>  
+        </tr>
         <tr>
             <td>prefix</td>
             <td>ReactNode</td>
             <td>Add a prefix to the submenu </td>
             <td>-</td>
-        </tr>  
+        </tr>
         <tr>
             <td>suffix</td>
             <td>ReactNode</td>
             <td>Add a suffix to the submenu </td>
             <td>-</td>
-        </tr>          
+        </tr>
     </tbody>
 </table>
+
+## Contributing
+
+### Online one-click setup
+
+You can use [Gitpod](https://www.gitpod.io/) (an Online Open Source VS Code-like IDE which is free for Open Source) for working on issues and making PRs to this project. With a single click it will launch a workspace and automatically:
+
+- clone this repo.
+- install all the dependencies.
+- run `yarn start:all`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
+so that you can start hacking around straight away without any friction.
 
 ## License
 


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone this repo.
- install all the dependencies.
- run `yarn start:all`.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/react-pro-sidebar

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95480500-685b4d80-09a5-11eb-8d4a-5c424a725acd.png)

 
