### PR TITLE
Allow conditionally add menu items

### DIFF
--- a/src/ProSidebar/Menu/Menu.tsx
+++ b/src/ProSidebar/Menu/Menu.tsx
@@ -25,12 +25,15 @@ const Menu: React.ForwardRefRenderFunction<unknown, Props> = (
       })}
     >
       <ul>
-        {React.Children.map(children, (child) =>
-          React.cloneElement(child as React.ReactElement, {
-            firstchild: 1,
-            popperarrow: popperArrow === true ? 1 : 0,
-          }),
-        )}
+        {React.Children.toArray(children)
+          .filter(Boolean)
+          .map((child, index) =>
+            React.cloneElement(child as React.ReactElement, {
+              key: index,
+              firstchild: 1,
+              popperarrow: popperArrow === true ? 1 : 0,
+            }),
+          )}
       </ul>
     </nav>
   );


### PR DESCRIPTION
# Description

Fix dynamically add `Menu` items depending on certain conditions.

```typescript
<Menu>
    <MenuItem />
    {false && (
        <MenuItem />
    )}
</Menu>
```

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Current behavior

It throws the following exception at runtime:

```javascript
Uncaught Error: React.cloneElement(...): The argument must be a React element, but you passed null.
```

## Updated/expected behavior 

Defensive programming checking for `null` or `undefined` children in `Menu` list items when calling `cloneElement` to avoid the invalid type assertion exception.