### PR TITLE
add title prop to MenuItem, SubMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,69 +217,81 @@ import { Link } from 'react-router-dom';
             <td><code>'square'</code> | <code>'round'</code> | <code>'circle'</code></td>
             <td>Shape of the menu icons </td>
             <td>-</td>
-        </tr>  
-         <tr>          
+        </tr>
+         <tr>
             <td>popperArrow</td>
             <td>boolean</td>
             <td>if <code>true</code>, an arrow will be displayed when sidebar collapsed to point to sub-menu wrapper</td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
-            <td rowspan=4>MenuItem</td>
+            <td rowspan=5>MenuItem</td>
+            <td>title</td>
+            <td>string</td>
+            <td>Title attribute for the menu item </td>
+            <td>-</td>
+        </tr>
+         <tr>
             <td>icon</td>
             <td>ReactNode</td>
             <td>Icon for the menu item </td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>active</td>
             <td>boolean</td>
             <td>Set active menu items </td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
             <td>prefix</td>
             <td>ReactNode</td>
             <td>Add a prefix to the menuItem </td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>suffix</td>
             <td>ReactNode</td>
             <td>Add a suffix to the menuItem </td>
             <td>-</td>
-        </tr>          
+        </tr>
         <tr>
-            <td rowspan=7>SubMenu</td>
-            <td>title</td>
+            <td rowspan=8>SubMenu</td>
+            <td>label</td>
             <td>string | ReactNode</td>
-            <td>Title for the submenu </td>
+            <td>Label for the submenu </td>
             <td>-</td>
-        </tr>  
+        </tr>
+         <tr>
+            <td>title</td>
+            <td>string</td>
+            <td>Title attribute for submenu</td>
+            <td>-</td>
+        </tr>
          <tr>
             <td>icon</td>
             <td>ReactNode</td>
             <td>Icon for submenu</td>
             <td>-</td>
-        </tr>  
+        </tr>
          <tr>
             <td>defaultOpen</td>
             <td>boolean</td>
             <td>Set if the submenu is open by default</td>
             <td><code>false</code></td>
-        </tr>  
+        </tr>
          <tr>
             <td>open</td>
             <td>boolean</td>
             <td>Set open value if you want to control the state</td>
             <td>-</td>
-        </tr>  
+        </tr>
         <tr>
             <td>prefix</td>
             <td>ReactNode</td>
             <td>Add a prefix to the submenu </td>
             <td>-</td>
-        </tr>  
+        </tr>
         <tr>
             <td>suffix</td>
             <td>ReactNode</td>

--- a/src/ProSidebar/Menu/MenuItem.tsx
+++ b/src/ProSidebar/Menu/MenuItem.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 export type Props = React.LiHTMLAttributes<HTMLLIElement> & {
   children?: React.ReactNode;
   className?: string;
+  title?: string;
   icon?: React.ReactNode;
   active?: boolean;
   prefix?: React.ReactNode;
@@ -13,14 +14,14 @@ export type Props = React.LiHTMLAttributes<HTMLLIElement> & {
 };
 
 const MenuItem: React.ForwardRefRenderFunction<unknown, Props> = (
-  { children, className, icon, active, prefix, suffix, firstchild, popperarrow, ...rest },
+  { children, className, title, icon, active, prefix, suffix, firstchild, popperarrow, ...rest },
   ref,
 ) => {
   const menuItemRef: LegacyRef<HTMLLIElement> = (ref as any) || React.createRef<HTMLLIElement>();
 
   return (
     <li ref={menuItemRef} className={classNames('pro-menu-item', className, { active })} {...rest}>
-      <div className="pro-inner-item" tabIndex={0} role="button">
+      <div className="pro-inner-item" tabIndex={0} role="button" {...(title ? { title } : {})}>
         {icon ? (
           <span className="pro-icon-wrapper">
             <span className="pro-icon">{icon}</span>

--- a/src/ProSidebar/Menu/SubMenu.tsx
+++ b/src/ProSidebar/Menu/SubMenu.tsx
@@ -9,7 +9,8 @@ export type Props = React.LiHTMLAttributes<HTMLLIElement> & {
   children?: React.ReactNode;
   className?: string;
   icon?: React.ReactNode;
-  title?: React.ReactNode;
+  title?: string;
+  label?: React.ReactNode;
   defaultOpen?: boolean;
   open?: boolean;
   prefix?: React.ReactNode;
@@ -25,6 +26,7 @@ const SubMenu: React.ForwardRefRenderFunction<unknown, Props> = (
     icon,
     className,
     title,
+    label,
     defaultOpen = false,
     open,
     prefix,
@@ -110,6 +112,7 @@ const SubMenu: React.ForwardRefRenderFunction<unknown, Props> = (
         onKeyPress={handleToggleSubMenu}
         role="button"
         tabIndex={0}
+        title={title}
       >
         {icon ? (
           <span className="pro-icon-wrapper">
@@ -117,7 +120,7 @@ const SubMenu: React.ForwardRefRenderFunction<unknown, Props> = (
           </span>
         ) : null}
         {prefix ? <span className="prefix-wrapper">{prefix}</span> : null}
-        <span className="pro-item-content">{title}</span>
+        <span className="pro-item-content">{label}</span>
         {suffix ? <span className="suffix-wrapper">{suffix}</span> : null}
         <span className="pro-arrow-wrapper">
           <span className="pro-arrow" />


### PR DESCRIPTION
* **add** `title` property to **MenuItem** (renders as title attribute)
* **add** `title` property to **SubMenu** (renders as title attribute)
* **rename** `title` property to `label` for **SubMenu** (to allow for title attribute)

There might be a case when users want to show title attribute that is different from the actual label of MenuItem and or SubMenu component. For example if title attribute contains more characters than label or if sidebar layout doesn't allow for multiple lines of text and characters that do not fit in one line are omitted.  This PR includes rename from 'title' prop to 'label' for SubMenu to allow for title prop.