### PR TITLE
remove extra closing parenthesis

### DIFF
--- a/storybook/stories/Sidebar.stories.tsx
+++ b/storybook/stories/Sidebar.stories.tsx
@@ -50,8 +50,7 @@ Basic.parameters = {
           </Sidebar>
           <main style={{ padding: 10 }}> Main content</main>
         </div>
-    );
-      )`,
+    );`,
     },
   },
 };


### PR DESCRIPTION
## Description
There is an extra closing parenthesis in the example code which is an error as it not required on this page https://azouaoui-med.github.io/react-pro-sidebar/?path=/docs/sidebar--basic

## Fixes 
Fixes #144 
By removing the extra parenthesis the code example can be fixed.

## Type of change

- [x] Documentation update
- [x] Refactoring / enhancement

## How Has This Been Tested?
No testing is required as this is only a string literal change which is not using any variable.
The code affected is in the example code on this page https://azouaoui-med.github.io/react-pro-sidebar/?path=/docs/sidebar--basic
