### PR TITLE
fix: useLayoutEffect to useIsomorphicLayoutEffect

### DIFF
--- a/src/components/SubMenu.tsx
+++ b/src/components/SubMenu.tsx
@@ -3,6 +3,7 @@ import styled, { CSSObject } from '@emotion/styled';
 import classnames from 'classnames';
 import { SubMenuContent } from './SubMenuContent';
 import { useSidebar } from '../hooks/useSidebar';
+import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
 import { StyledMenuLabel } from '../styles/StyledMenuLabel';
 import { StyledMenuIcon } from '../styles/StyledMenuIcon';
 import { StyledMenuPrefix } from '../styles/StyledMenuPrefix';
@@ -191,7 +192,7 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
     }
   };
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setTimeout(() => popperInstance?.update(), transitionDuration);
     if (collapsed && level === 0) {
       setOpenWhenCollapsed(false);

--- a/src/hooks/useIsomorphicLayoutEffect.tsx
+++ b/src/hooks/useIsomorphicLayoutEffect.tsx
@@ -1,0 +1,4 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+


### PR DESCRIPTION
## Description

useLayoutEffect has been changed to useIsomorphicLayoutEffect custom hook because an error was exposed in the ssr environment.

useLayoutEffect generates the following warning in the SSR environment.
👉. [link](https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85)

`Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format.
`

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / enhancement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
