### PR TITLE
Add additional utility class for openWhenCollapsed property

### DIFF
--- a/src/components/SubMenu.tsx
+++ b/src/components/SubMenu.tsx
@@ -329,6 +329,7 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
     [menuClasses.active]: active,
     [menuClasses.disabled]: disabled,
     [menuClasses.open]: openControlled ?? open,
+    [menuClasses.openWhenCollapsed]: openWhenCollapsed,
   };
 
   return (

--- a/src/utils/utilityClasses.ts
+++ b/src/utils/utilityClasses.ts
@@ -23,4 +23,5 @@ export const menuClasses = {
   disabled: 'ps-disabled',
   active: 'ps-active',
   open: 'ps-open',
+  openWhenCollapsed: 'ps-open-when-collapsed',
 };


### PR DESCRIPTION
See issue #198

This PR adds a class depending on the openWhenCollapsed property. This will allow users to customize styling for opened submenus while the sidebar is collapsed.