### PR TITLE
Updated class name from '&.active' to '&.ps-active'

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ import { Link } from 'react-router-dom';
   <Menu
     menuItemStyles={{
       button: {
-        // the active class will be added automatically by react router
+        // the active[ps-active] class will be added automatically by react router
         // so we can use it to style the active menu item
-        [`&.active`]: {
+        [`&.ps-active`]: {
           backgroundColor: '#13395e',
           color: '#b6c8d9',
         },


### PR DESCRIPTION
## Description

This pull request addresses an issue with the active class name for the MenuItem component, as defined in the README file. The README suggests using [&.active] for styling, but after inspecting the added class name in the browser, it appears as "ps-active" instead of "active".

## Type of change

-Changes Made:

Updated the class name from [&.active] to [&.ps-active] in the MenuItem styles.
With this change, the defined styles for [&.ps-active] now take effect as expected.

## Documentation Update:

Updated the README file to reflect the correct active class name as [&.ps-active]. It's important for everyone to be aware of this change when styling the MenuItem component.

## Testing:

Confirmed the issue by inspecting the class name in the browser.
Applied the fix and verified that the correct styles are now applied when the menu item is active.

### Additional Notes:
No issue number was associated with this change as it is a small fix to align with the actual class name being applied in the code.


