### PR TITLE
add role="button" to work for tabIndex when using sidebar with TAB key

### DIFF
--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -164,6 +164,7 @@ export const MenuItemFR: React.ForwardRefRenderFunction<HTMLLIElement, MenuItemP
         data-testid={`${menuClasses.button}-test-id`}
         component={component}
         tabIndex={0}
+        role="button"
         {...rest}
       >
         {icon && (

--- a/src/components/SubMenu.tsx
+++ b/src/components/SubMenu.tsx
@@ -358,6 +358,7 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
         onKeyUp={handleOnKeyUp}
         component={component}
         tabIndex={0}
+        role={"button"}
         {...rest}
       >
         {icon && (


### PR DESCRIPTION
## Description

I have added role="button" so that working expected when using TAB key.

Fixes (#243 )

## Type of change

- [#243  ] Bug fix

## How Has This Been Tested?

Please find the attached video which show working fine with TAB key press 

Uploading TAB_issue_fix.mp4…

when the SubMenu and Its MenuItems (are in Open/Close state).
