### PR TITLE
V2-ALPHA.1

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "react-pro-sidebar": "2.0.0-alpha.0"
+  },
+  "changesets": []
+}

--- a/.changeset/ssr-next-fixes.md
+++ b/.changeset/ssr-next-fixes.md
@@ -1,0 +1,5 @@
+---
+'react-pro-sidebar': major
+---
+
+v2 SSR/Next.js fixes: breakpoint no longer flashes the sidebar open before hydration (applied via a CSS media query); popper flyouts are portaled out of the scroll container so `overflow`/`backdrop-filter` can't clip or mis-position them, while keeping color/font/direction; RTL and the React 19 `inert` warning fixed; `onBreakPoint` fires only on change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[Sidebar]** Backdrop now uses `onKeyDown` and activates only on `Enter` / `Space` (replacing the deprecated `onKeyPress`, which fired on any key)
 - **[SubMenu]** Items in a closed submenu are no longer reachable via Tab or exposed to screen readers — the closed submenu content is now marked `inert`
 - **[SubMenu]** Trigger now has `role="button"`, so its `aria-expanded` / `aria-haspopup` state is valid (it previously sat on a roleless `<a>`)
+- **[Sidebar]** `breakPoint` now works under SSR (Next.js): the responsive hide is applied with a CSS media query so the sidebar is hidden on first paint, instead of flashing open until hydration
 
 ## [1.1.0] - 2024-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[SubMenu]** Items in a closed submenu are no longer reachable via Tab or exposed to screen readers — the closed submenu content is now marked `inert`
 - **[SubMenu]** Trigger now has `role="button"`, so its `aria-expanded` / `aria-haspopup` state is valid (it previously sat on a roleless `<a>`)
 - **[Sidebar]** `breakPoint` now works under SSR (Next.js): the responsive hide is applied with a CSS media query so the sidebar is hidden on first paint, instead of flashing open until hydration
+- **[SubMenu]** Popper flyouts (collapsed / `popover` mode) are now portaled out of the sidebar's scroll container, so its `overflow` / `backdrop-filter` no longer clips or mis-positions them (they still inherit the sidebar's color, font and direction)
 
 ## [1.1.0] - 2024-02-03
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -98,9 +98,34 @@ interface StyledSidebarProps extends Omit<SidebarProps, 'backgroundColor'> {
   toggled?: boolean;
   broken?: boolean;
   rtl?: boolean;
+  /** Media query (e.g. `(max-width: 768px)` / `screen`) at which to hide via CSS. */
+  breakpointMediaQuery?: string;
 }
 
 type StyledSidebarContainerProps = Pick<SidebarProps, 'backgroundColor'>;
+
+// Off-canvas (broken/overlay) layout: fixed and slid off-screen, brought back
+// when toggled. Shared by the CSS media query and the runtime `broken` class so
+// the two never drift.
+const brokenLayout = ({
+  rtl,
+  width,
+  collapsedWidth,
+}: Pick<StyledSidebarProps, 'rtl' | 'width' | 'collapsedWidth'>) => `
+  position: fixed;
+  height: 100%;
+  top: 0px;
+  z-index: 100;
+  ${rtl ? `right: -${width};` : `left: -${width};`}
+
+  &.${sidebarClasses.collapsed} {
+    ${rtl ? `right: -${collapsedWidth};` : `left: -${collapsedWidth};`}
+  }
+
+  &.${sidebarClasses.toggled} {
+    ${rtl ? `right: 0;` : `left: 0;`}
+  }
+`;
 
 const StyledSidebar = styled.aside<StyledSidebarProps>`
   position: relative;
@@ -126,33 +151,19 @@ const StyledSidebar = styled.aside<StyledSidebarProps>`
     border-left-style: solid;
   }
 
+  /*
+   * Hide below the breakpoint with a real CSS media query so the correct
+   * (hidden) layout is painted on the very first load — before JS runs and
+   * hydrates. Without this, SSR (e.g. Next.js) renders the sidebar visible
+   * (the server can't know the viewport), causing a flash before the runtime
+   * \`broken\` state hides it.
+   */
+  ${({ breakpointMediaQuery, ...props }) =>
+    breakpointMediaQuery ? `@media ${breakpointMediaQuery} { ${brokenLayout(props)} }` : ''}
+
+  /* Runtime broken state (covers resize after mount; also a styling hook). */
   &.${sidebarClasses.broken} {
-    position: fixed;
-    height: 100%;
-    top: 0px;
-    z-index: 100;
-
-    ${({ rtl, width }) => (!rtl ? `left: -${width};` : '')}
-
-    &.${sidebarClasses.collapsed} {
-      ${({ rtl, collapsedWidth }) => (!rtl ? `left: -${collapsedWidth}; ` : '')}
-    }
-
-    &.${sidebarClasses.toggled} {
-      ${({ rtl }) => (!rtl ? `left: 0;` : '')}
-    }
-
-    &.${sidebarClasses.rtl} {
-      right: -${({ width }) => width};
-
-      &.${sidebarClasses.collapsed} {
-        right: -${({ collapsedWidth }) => collapsedWidth};
-      }
-
-      &.${sidebarClasses.toggled} {
-        right: 0;
-      }
-    }
+    ${(props) => brokenLayout(props)}
   }
 
   ${({ rootStyles }) => rootStyles}
@@ -237,7 +248,8 @@ export const Sidebar = React.forwardRef<HTMLHtmlElement, SidebarProps>(
       onBreakPoint?.(broken);
     };
 
-    const broken = useMediaQuery(getBreakpointValue());
+    const breakpointMediaQuery = getBreakpointValue();
+    const broken = useMediaQuery(breakpointMediaQuery);
 
     const collapsedValue = collapsed;
     const toggledValue = toggled;
@@ -274,8 +286,17 @@ export const Sidebar = React.forwardRef<HTMLHtmlElement, SidebarProps>(
       [collapsedValue, toggledValue, rtl, transitionDuration],
     );
 
+    // Notify `onBreakPoint` only when the broken state actually changes.
+    // `broken` starts `false` (deterministic for SSR) and settles via a layout
+    // effect, so a viewport that already matches would otherwise emit a
+    // spurious `false` before the settled `true`. The `false` baseline means
+    // the default (non-broken) state is never re-announced on mount.
+    const prevBrokenRef = React.useRef(false);
     React.useEffect(() => {
-      breakpointCallbackFnRef.current?.(broken);
+      if (broken !== prevBrokenRef.current) {
+        prevBrokenRef.current = broken;
+        breakpointCallbackFnRef.current?.(broken);
+      }
     }, [broken]);
 
     // When the sidebar opens as an overlay (broken + toggled), move focus to it
@@ -311,6 +332,7 @@ export const Sidebar = React.forwardRef<HTMLHtmlElement, SidebarProps>(
           width={width}
           collapsedWidth={collapsedWidth}
           transitionDuration={transitionDuration}
+          breakpointMediaQuery={breakpointMediaQuery}
           className={classnames(
             sidebarClasses.root,
             {

--- a/src/components/SubMenu.tsx
+++ b/src/components/SubMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import styled, { CSSObject } from '@emotion/styled';
 import classnames from 'classnames';
 import { SubMenuContent } from './SubMenuContent';
@@ -7,7 +8,7 @@ import { StyledMenuIcon } from '../styles/StyledMenuIcon';
 import { StyledMenuPrefix } from '../styles/StyledMenuPrefix';
 import { useMenu } from '../hooks/useMenu';
 import { StyledMenuSuffix } from '../styles/StyledMenuSuffix';
-import { menuClasses } from '../utils/utilityClasses';
+import { menuClasses, sidebarClasses } from '../utils/utilityClasses';
 import {
   StyledExpandIcon,
   StyledExpandIconCollapsed,
@@ -176,11 +177,25 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
   const [internalOpen, setInternalOpen] = React.useState(!!defaultOpen);
   const [openWhenCollapsed, setOpenWhenCollapsed] = React.useState(false);
 
+  // Popper content is portaled out of the scroll container (see render), but
+  // only after mount so the server and first client render stay inline and
+  // hydration matches. We portal to the sidebar root rather than <body>: it's
+  // outside the container's `overflow` / `backdrop-filter` (the things that
+  // clip or trap a fixed flyout) yet still a sidebar descendant, so the flyout
+  // keeps inheriting the sidebar's color and font. Falls back to <body> when
+  // there's no sidebar ancestor.
+  const [portalNode, setPortalNode] = React.useState<HTMLElement | null>(null);
+  React.useEffect(() => {
+    const root = buttonRef.current?.closest(`.${sidebarClasses.root}`);
+    setPortalNode((root as HTMLElement | null) ?? document.body);
+  }, []);
+
   const buttonRef = React.useRef<HTMLAnchorElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
   const { popperInstance } = usePopper({
     popper: isPopper,
+    mounted: !!portalNode,
     buttonRef,
     contentRef,
   });
@@ -295,11 +310,12 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
   const getSubMenuItemStyles = (element: MenuItemElement): CSSObject | undefined =>
     resolveElementStyles(menuItemStyles, element, styleParams);
 
-  // Reposition the popper after the sidebar's collapse/rtl transition.
+  // Reposition the popper after the sidebar's collapse/rtl transition, and once
+  // the content has been portaled to <body> on mount.
   React.useEffect(() => {
     const timer = setTimeout(() => popperInstance?.update(), sidebarTransitionDuration);
     return () => clearTimeout(timer);
-  }, [collapsed, level, rtl, sidebarTransitionDuration, popperInstance]);
+  }, [collapsed, level, rtl, sidebarTransitionDuration, popperInstance, portalNode]);
 
   // Reset the popper to closed when the popper mode toggles (entering collapsed
   // or popover mode) — not when the popper instance first becomes available.
@@ -359,6 +375,33 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
     [menuClasses.disabled]: disabled,
     [menuClasses.open]: open,
   };
+
+  const submenuInner = (
+    <SubMenuContent
+      ref={contentRef}
+      openWhenCollapsed={openWhenCollapsed}
+      open={open}
+      popper={isPopper}
+      rtl={rtl}
+      className={classnames(menuClasses.subMenuContent, sharedClasses)}
+      rootStyles={getSubMenuItemStyles('subMenuContent')}
+    >
+      <LevelContext.Provider value={level + 1}>
+        <AccordionContext.Provider value={childAccordionContext}>
+          <SubMenuActiveContext.Provider value={activeContextValue}>
+            {children}
+          </SubMenuActiveContext.Provider>
+        </AccordionContext.Provider>
+      </LevelContext.Provider>
+    </SubMenuContent>
+  );
+
+  // In popper mode, portal the content to the sidebar root so the scroll
+  // container's `overflow` / `backdrop-filter` can't clip or mis-position the
+  // fixed flyout — while still inheriting the sidebar's color/font. Portaled
+  // only after mount so SSR and the first client render stay inline.
+  const subMenuContent =
+    isPopper && portalNode ? createPortal(submenuInner, portalNode) : submenuInner;
 
   return (
     <StyledSubMenu
@@ -457,22 +500,7 @@ export const SubMenuFR: React.ForwardRefRenderFunction<HTMLLIElement, SubMenuPro
         </StyledExpandIconWrapper>
       </MenuButton>
 
-      <SubMenuContent
-        ref={contentRef}
-        openWhenCollapsed={openWhenCollapsed}
-        open={open}
-        popper={isPopper}
-        className={classnames(menuClasses.subMenuContent, sharedClasses)}
-        rootStyles={getSubMenuItemStyles('subMenuContent')}
-      >
-        <LevelContext.Provider value={level + 1}>
-          <AccordionContext.Provider value={childAccordionContext}>
-            <SubMenuActiveContext.Provider value={activeContextValue}>
-              {children}
-            </SubMenuActiveContext.Provider>
-          </AccordionContext.Provider>
-        </LevelContext.Provider>
-      </SubMenuContent>
+      {subMenuContent}
     </StyledSubMenu>
   );
 };

--- a/src/components/SubMenuContent.tsx
+++ b/src/components/SubMenuContent.tsx
@@ -10,6 +10,11 @@ interface SubMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
   openWhenCollapsed?: boolean;
   /** Render as a floating popper (collapsed top-level submenu, or popover mode). */
   popper?: boolean;
+  /**
+   * RTL direction. Needed because popper content is portaled to `<body>` and no
+   * longer inherits `direction: rtl` from the sidebar ancestor.
+   */
+  rtl?: boolean;
   rootStyles?: CSSObject;
   children?: React.ReactNode;
 }
@@ -64,7 +69,7 @@ const StyledSubMenuContent = styled.div<SubMenuContentProps>`
 `;
 
 const SubMenuContentFR: React.ForwardRefRenderFunction<HTMLDivElement, SubMenuContentProps> = (
-  { children, open, openWhenCollapsed, popper, ...rest },
+  { children, open, openWhenCollapsed, popper, rtl, ...rest },
   ref,
 ) => {
   const { transitionDuration } = useMenu();
@@ -73,15 +78,18 @@ const SubMenuContentFR: React.ForwardRefRenderFunction<HTMLDivElement, SubMenuCo
   // submenu slides open based on `open`. While hidden, mark the subtree `inert`
   // so its links stay out of the tab order and the accessibility tree.
   const isVisible = popper ? !!openWhenCollapsed : !!open;
-  // `inert` is a real boolean prop in React 19 (an empty string is falsy and
-  // gets dropped), but untyped in React 18 — pass boolean `true` and apply it
-  // untyped so it renders a present attribute on both.
-  const inertProps = (isVisible ? {} : { inert: 'true' }) as object;
+  // `inert` is a real boolean attribute in React 19 — passing the string
+  // "true" there logs a warning — but React 18 doesn't recognize `inert` and
+  // only renders its string form (it drops a boolean `true`). Pick the
+  // representation the running React version renders as a present attribute.
+  const inertValue: true | 'true' = parseInt(React.version, 10) >= 19 ? true : 'true';
+  const inertProps = (isVisible ? {} : { inert: inertValue }) as object;
 
   return (
     <StyledSubMenuContent
       data-testid={`${menuClasses.subMenuContent}-test-id`}
       ref={ref}
+      dir={rtl ? 'rtl' : undefined}
       popper={popper}
       open={open}
       openWhenCollapsed={openWhenCollapsed}

--- a/src/hooks/useMediaQuery.tsx
+++ b/src/hooks/useMediaQuery.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 
-export const useMediaQuery = (breakpoint?: string): boolean => {
-  const [matches, setMatches] = React.useState(
-    !!breakpoint && typeof window !== 'undefined' && window.matchMedia(breakpoint).matches,
-  );
+// useLayoutEffect on the client so the correct value is committed before the
+// browser paints (no flash of the wrong layout); fall back to useEffect on the
+// server to avoid React's "useLayoutEffect does nothing on the server" warning.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
-  React.useEffect(() => {
+export const useMediaQuery = (breakpoint?: string): boolean => {
+  // Always start `false` so the server render and the first client render
+  // agree. Reading `window.matchMedia` in the initializer would make the
+  // hydration render disagree with the server; React would keep the server
+  // markup and the later sync (setting the same value) would be a no-op,
+  // leaving the wrong layout committed — exactly the SSR bug this avoids.
+  const [matches, setMatches] = React.useState(false);
+
+  useIsomorphicLayoutEffect(() => {
     if (!breakpoint || typeof window === 'undefined') return undefined;
 
     const media = window.matchMedia(breakpoint);
@@ -13,7 +22,7 @@ export const useMediaQuery = (breakpoint?: string): boolean => {
     // setMatches with the current value; React bails out if it's unchanged.
     const handleMatch = () => setMatches(media.matches);
 
-    // Sync in case the match changed between render and effect.
+    // Sync the real value once mounted (and whenever the query changes).
     handleMatch();
 
     media.addEventListener('change', handleMatch);

--- a/src/hooks/usePopper.tsx
+++ b/src/hooks/usePopper.tsx
@@ -5,6 +5,13 @@ import { SidebarContext } from '../components/Sidebar';
 interface PopperOptions {
   /** Whether this submenu should render as a floating popper. */
   popper: boolean;
+  /**
+   * Whether the content is in its final DOM location (it is portaled to
+   * `<body>` after mount). Creating the popper before this would bind it to the
+   * pre-portal node, which is then remounted — leaving the visible node
+   * unpositioned.
+   */
+  mounted: boolean;
   buttonRef: React.RefObject<HTMLAnchorElement>;
   contentRef: React.RefObject<HTMLDivElement>;
 }
@@ -14,18 +21,23 @@ interface PopperResult {
 }
 
 export const usePopper = (options: PopperOptions): PopperResult => {
-  const { popper, buttonRef, contentRef } = options;
+  const { popper, mounted, buttonRef, contentRef } = options;
 
   const { toggled, transitionDuration } = React.useContext(SidebarContext);
-  const popperInstanceRef = React.useRef<ReturnType<typeof createPopper> | undefined>();
+
+  // Keep the instance in state (not just a ref) so consumers re-render and can
+  // reliably call `.update()` once the popper exists.
+  const [popperInstance, setPopperInstance] = React.useState<
+    ReturnType<typeof createPopper> | undefined
+  >();
 
   /**
    * Create the popper instance only when the submenu renders as a popper
    * (collapsed top-level submenu, or `popover` mode while expanded).
    */
   React.useEffect(() => {
-    if (popper && contentRef.current && buttonRef.current) {
-      popperInstanceRef.current = createPopper(buttonRef.current, contentRef.current, {
+    if (popper && mounted && contentRef.current && buttonRef.current) {
+      const instance = createPopper(buttonRef.current, contentRef.current, {
         placement: 'right',
         strategy: 'fixed',
         modifiers: [
@@ -37,20 +49,29 @@ export const usePopper = (options: PopperOptions): PopperResult => {
           },
         ],
       });
+      setPopperInstance(instance);
+
+      return () => {
+        instance.destroy();
+        setPopperInstance(undefined);
+      };
     }
 
-    return () => popperInstanceRef.current?.destroy();
-  }, [popper, contentRef, buttonRef]);
+    return undefined;
+  }, [popper, mounted, contentRef, buttonRef]);
 
   /**
-   * update popper instance (position) when buttonRef or contentRef changes
+   * Keep the popper positioned: update when the trigger/content resize and once
+   * the sidebar's collapse/toggle transition settles.
    */
   React.useEffect(() => {
+    if (!popperInstance) return undefined;
+
     let resizeObserver: ResizeObserver | undefined;
 
     if (contentRef.current && buttonRef.current) {
       resizeObserver = new ResizeObserver(() => {
-        popperInstanceRef.current?.update();
+        popperInstance.update();
       });
 
       resizeObserver.observe(contentRef.current);
@@ -58,14 +79,14 @@ export const usePopper = (options: PopperOptions): PopperResult => {
     }
 
     const timer = setTimeout(() => {
-      popperInstanceRef.current?.update();
+      popperInstance.update();
     }, transitionDuration);
 
     return () => {
       resizeObserver?.disconnect();
       clearTimeout(timer);
     };
-  }, [transitionDuration, toggled, contentRef, buttonRef]);
+  }, [popperInstance, transitionDuration, toggled, contentRef, buttonRef]);
 
-  return { popperInstance: popperInstanceRef.current };
+  return { popperInstance };
 };

--- a/tests/Sidebar.test.tsx
+++ b/tests/Sidebar.test.tsx
@@ -214,4 +214,30 @@ describe('Sidebar', () => {
       expect(onBackdropClick).not.toHaveBeenCalled();
     });
   });
+
+  describe('onBreakPoint', () => {
+    it('does not announce the default (non-broken) state on mount', () => {
+      const onBreakPoint = vi.fn();
+      vi.spyOn(mediaQueryHook, 'useMediaQuery').mockImplementation(() => false);
+      customRender(
+        <Sidebar breakPoint="md" onBreakPoint={onBreakPoint}>
+          Sidebar
+        </Sidebar>,
+      );
+      // `broken` starts false and stays false — no spurious callback.
+      expect(onBreakPoint).not.toHaveBeenCalled();
+    });
+
+    it('announces the broken state once when it becomes broken', () => {
+      const onBreakPoint = vi.fn();
+      vi.spyOn(mediaQueryHook, 'useMediaQuery').mockImplementation(() => true);
+      customRender(
+        <Sidebar breakPoint="md" onBreakPoint={onBreakPoint}>
+          Sidebar
+        </Sidebar>,
+      );
+      expect(onBreakPoint).toHaveBeenCalledTimes(1);
+      expect(onBreakPoint).toHaveBeenCalledWith(true);
+    });
+  });
 });

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -124,13 +124,19 @@ describe('usePopper', () => {
 
   it('does not create a popper when popper is false', () => {
     const { buttonRef, contentRef } = makeRefs();
-    renderHook(() => usePopper({ popper: false, buttonRef, contentRef }));
+    renderHook(() => usePopper({ popper: false, mounted: true, buttonRef, contentRef }));
+    expect(createPopper).not.toHaveBeenCalled();
+  });
+
+  it('does not create a popper until mounted (content portaled)', () => {
+    const { buttonRef, contentRef } = makeRefs();
+    renderHook(() => usePopper({ popper: true, mounted: false, buttonRef, contentRef }));
     expect(createPopper).not.toHaveBeenCalled();
   });
 
   it('creates a popper when popper is true', () => {
     const { buttonRef, contentRef } = makeRefs();
-    renderHook(() => usePopper({ popper: true, buttonRef, contentRef }));
+    renderHook(() => usePopper({ popper: true, mounted: true, buttonRef, contentRef }));
     expect(createPopper).toHaveBeenCalledWith(
       buttonRef.current,
       contentRef.current,
@@ -152,7 +158,9 @@ describe('usePopper', () => {
     global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
     const { buttonRef, contentRef } = makeRefs();
-    const { unmount } = renderHook(() => usePopper({ popper: true, buttonRef, contentRef }));
+    const { unmount } = renderHook(() =>
+      usePopper({ popper: true, mounted: true, buttonRef, contentRef }),
+    );
 
     expect(observe).toHaveBeenCalled();
     expect(disconnect).not.toHaveBeenCalled();

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * This is an SSR/hydration test: it drives `renderToString` + `hydrateRoot`
+ * and inspects the DOM directly, which the Testing Library lint rules don't
+ * model. Disable the two that misfire here.
+ */
+/* eslint-disable testing-library/render-result-naming-convention, testing-library/no-node-access */
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot } from 'react-dom/client';
+import { act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Menu, MenuItem, Sidebar } from '../src';
+import { sidebarClasses } from '../src/utils/utilityClasses';
+
+const mockMatchMedia = (matches: boolean) => {
+  const listeners = new Set<() => void>();
+  const mql = {
+    matches,
+    media: '',
+    addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) => listeners.delete(cb),
+  };
+  window.matchMedia = vi.fn().mockImplementation(() => mql) as unknown as typeof window.matchMedia;
+  return mql;
+};
+
+describe('SSR / hydration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('applies the broken state after hydration when the viewport already matches', () => {
+    // Viewport is already below the breakpoint at first paint.
+    mockMatchMedia(true);
+
+    const app = (
+      <Sidebar breakPoint="400px">
+        <Menu>
+          <MenuItem>Item</MenuItem>
+        </Menu>
+      </Sidebar>
+    );
+
+    // Server render is deterministic: no `broken` class (matchMedia is not
+    // consulted until the client effect runs).
+    const html = renderToString(app);
+    expect(html).not.toContain(sidebarClasses.broken);
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    document.body.appendChild(container);
+
+    // Hydrate. The first client render must agree with the server (no broken
+    // class), then the effect flips it on — the regression was that the flip
+    // never committed, leaving the sidebar visible.
+    act(() => {
+      hydrateRoot(container, app);
+    });
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain(sidebarClasses.broken);
+  });
+});


### PR DESCRIPTION
- Breakpoint flash under SSR — the sidebar rendered visible on the server and only hid after hydration, causing a flash on viewports below the breakpoint. The responsive hide is now applied via a real CSS @media query (derived from breakPoint, predefined or custom), so it's correct on first paint, before JS runs.

- useMediaQuery SSR-safety — starts deterministically (false) and syncs in an isomorphic layout effect, avoiding hydration mismatch.

onBreakPoint now fires only when the broken state actually changes — no spurious initial false before the settled value.

- Clipped popover/collapsed flyouts — a position: fixed flyout was trapped and clipped when the sidebar container had overflow + backdrop-filter (the latter makes it a containing block for fixed descendants). The flyout is now portaled out of the scroll container to the sidebar root, so it can't be clipped or mis-positioned — while still inheriting the sidebar's color, font, and direction.

- RTL — flyout content is explicitly marked dir="rtl" so it stays mirrored when portaled.

- inert React 19 warning — pick the representation each React version renders correctly (boolean on 19, string on 18).

- Positioning — Popper is created only after the content is in its final (portaled) location, so it binds to the visible node; usePopper exposes the instance via state so repositioning fires reliably.